### PR TITLE
Send a confirmation remark for blind rolls

### DIFF
--- a/modron/interact/dice_roll.py
+++ b/modron/interact/dice_roll.py
@@ -208,9 +208,14 @@ class DiceRollInteraction(InteractionModule):
 
         # Send the message
         if args.blind:
+            # Send the dice roll to the blind channel
             channel_name = config.team_options[context.guild.id].blind_channel
             channel: TextChannel = utils.get(context.guild.channels, name=channel_name)
             await channel.send(reply)
+
+            # Send a confirmation message as a reply
+            await context.send(f'@!{context.author.id}> rolled {roll.roll_description}, and '
+                               'only the GM will see the result')
         else:
             await context.send(reply)
 

--- a/modron/tests/interact/test_dice_command.py
+++ b/modron/tests/interact/test_dice_command.py
@@ -62,7 +62,7 @@ async def test_rolling(parser, roller: DiceRollInteraction, payload: MockContext
     # Test a blind roll
     args = parser.parse_args(['luck', '--blind'])
     await roller.interact(args, payload)
-    assert 'for luck' in payload.last_message
+    assert 'rolled 1d20' in payload.last_message
 
     # Make sure the log file does not yet exist
     print(f'Checking if the log was created or modified at {log_path}')


### PR DESCRIPTION
So the roller knows that the correct dice were rolled.