### PR TITLE
Better detection of last message

### DIFF
--- a/modron/discord.py
+++ b/modron/discord.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 from datetime import datetime
 import logging
 
-from discord import TextChannel, Message, Member, Forbidden
+from discord import TextChannel, Message, Forbidden
 
 from modron.utils import get_local_tz_offset
 

--- a/modron/discord.py
+++ b/modron/discord.py
@@ -10,14 +10,14 @@ from modron.utils import get_local_tz_offset
 logger = logging.getLogger(__name__)
 
 
-async def get_last_activity(channel: TextChannel) -> Optional[Tuple[datetime, Optional[Member]]]:
+async def get_last_activity(channel: TextChannel) -> Optional[Tuple[datetime, Optional[Message]]]:
     """Get the last activity on a certain text channel
 
     Args:
         channel: Link to the channel
     Returns:
         - Time of the last message (if available)
-        - Whether the message was from the bot user
+        - The message object
     """
 
     try:
@@ -28,7 +28,7 @@ async def get_last_activity(channel: TextChannel) -> Optional[Tuple[datetime, Op
         logger.warning(f'Bot lacks access to channel: {channel.name}')
         return datetime.fromtimestamp(0), None
     if message is not None:
-        return message.created_at.replace(tzinfo=None) + get_local_tz_offset(), message.author
+        return message.created_at.replace(tzinfo=None) + get_local_tz_offset(), message
 
     # Return a datetime of now for channels that have yet to be written in
     return datetime.fromtimestamp(0), None

--- a/modron/interact/reminder.py
+++ b/modron/interact/reminder.py
@@ -76,6 +76,11 @@ class ReminderModule(InteractionModule):
             state = ModronState.load()
             reminder_time = state.reminder_time[context.guild.id]
             reply = f'Next check for reminder: <t:{int(reminder_time.timestamp())}>'  # Format as a time
+
+            # Display the last message
+            if state.last_message is not None:
+                reply += f"\n\nLast message was from {state.last_message.sender} in #{state.last_message.channel}" \
+                         f" at <t:{int(state.last_message.last_time.timestamp())}"
         elif args.reminder_command == 'break':
             reply = _add_delay(context.guild.id, args.time)
         else:

--- a/modron/interact/reminder.py
+++ b/modron/interact/reminder.py
@@ -75,11 +75,11 @@ class ReminderModule(InteractionModule):
             # Get the reminder time as a time
             state = ModronState.load()
             reminder_time = state.reminder_time[context.guild.id]
-            reply = f'Next check for reminder: <t:{int(reminder_time.timestamp())}>'  # Format as a
+            reply = f'Next check for reminder: <t:{int(reminder_time.timestamp())}>'  # Format as a time
         elif args.reminder_command == 'break':
             reply = _add_delay(context.guild.id, args.time)
         else:
             raise ValueError('Support for {args.reminder_command} has not been implemented (blame Logan)')
 
-        # Send reply back to user
+        # Reply to user
         await context.reply(reply)

--- a/modron/services/reminder.py
+++ b/modron/services/reminder.py
@@ -9,7 +9,7 @@ from discord import Guild, TextChannel, AllowedMentions, CategoryChannel, Messag
 from discord import utils
 
 from modron.config import config
-from modron.db import ModronState
+from modron.db import ModronState, LastMessage
 from modron.discord import get_last_activity
 from modron.services import BaseService
 from modron.utils import get_local_tz_offset
@@ -92,23 +92,27 @@ class ReminderService(BaseService):
         # Determine the last activity
         last_time = await self.assess_last_activity()
         stall_time = datetime.now() - last_time
-        logger.info(f'Most recent post was {stall_time} ago in {self.active_channel}')
+        logger.info(f'Most recent post was {stall_time} ago in {self.active_channel} '
+                    f'by {self.last_message.author.name}')
         self.last_channel_poll = datetime.now()
 
         # Determine when we would issue a reminder based on activity
         state = ModronState.load()
         reminder_time = last_time + self.allowed_stall_time
 
+        # Update the lass message in the state
+        state.last_message = LastMessage.from_discord(self.last_message)
+
         # If it is after any previous reminder time, replace that reminder time
         team_reminder_time = state.reminder_time.get(self._guild.id, None)
         if team_reminder_time is None or reminder_time > team_reminder_time:
             logger.info(f'Moving up the next reminder time to: {reminder_time}')
             state.reminder_time[self._guild.id] = reminder_time
-            state.save()
         else:
             logger.info(f'Activity-based reminder would be sooner '
                         f'than user-specified reminder: {team_reminder_time}. Not updating reminder time')
             reminder_time = state.reminder_time[self._guild.id]
+        state.save()
 
         # Check if we are past the stall time
         if datetime.now() > reminder_time:
@@ -170,11 +174,12 @@ class ReminderService(BaseService):
 
         # Check every channel
         tasks = [await get_last_activity(c) for c in self.watch_channels]
-        last_times, self.last_message = zip(*tasks)
+        last_times, last_messages = zip(*tasks)
 
         # Get the most recent activity and info on most recent channel
         last_time = max(last_times)
         self.time_last_activity = last_time
         active_channel_ind = last_times.index(last_time)
+        self.last_message = last_messages[active_channel_ind]
         self.active_channel = self.watch_channels[active_channel_ind]
         return last_time

--- a/modron/tests/interact/test_reminder.py
+++ b/modron/tests/interact/test_reminder.py
@@ -1,12 +1,18 @@
 from pytest import mark
 
 from modron.interact.reminder import ReminderModule
+from modron.services.reminder import ReminderService
 
 rem = ReminderModule()
 
 
 @mark.asyncio
-async def test_delay_status(payload):
+async def test_delay_status(payload, guild):
+    # Update the state by checking for the last message
+    service = ReminderService(guild, "ic_all", 853806638346534962)  # Look at all IC channels
+    await service.assess_last_activity()
+
+    # Run a status check
     args = rem.parser.parse_args(['status'])
     await rem.interact(args, payload)
     assert payload.last_message.startswith('Next check')

--- a/modron/tests/interact/test_reminder.py
+++ b/modron/tests/interact/test_reminder.py
@@ -10,6 +10,7 @@ async def test_delay_status(payload):
     args = rem.parser.parse_args(['status'])
     await rem.interact(args, payload)
     assert payload.last_message.startswith('Next check')
+    assert 'was from' in payload.last_message
 
 
 @mark.asyncio


### PR DESCRIPTION
Had a problem where we only looked at the activity in #ic_all to determine whether a reminder need be sent.

We fix that and let you ask Modron from Discord what the last message was.