### PR TITLE
Send a confirmation message for reminder requests

### DIFF
--- a/modron/interact/followup.py
+++ b/modron/interact/followup.py
@@ -45,13 +45,20 @@ class FollowupModule(InteractionModule):
         reply_channel = context.channel
         if context.author.id in team_options.private_channels:
             reply_channel = utils.get(context.guild.channels, name=team_options.private_channels[context.author.id])
-        logger.info(f'Watching for reminders on {context.channel.name}, reminding user on {reply_channel.name}')
+        logger.info(f'Watching for reminders on {context.channel.name},'
+                    f' reminding user on {reply_channel.name} at {datetime.now() + duration}')
 
         # Set up a timer to reply when that occurs
         task = asyncio.create_task(
             self.reply_if_needed(duration, context.author, context.channel, reply_channel)
         )
         logger.info('Submitted a reminder to run as a co-routine')
+
+        # Send a confirmation to the user
+        await context.reply(
+            f'Ok! I\'ll remind you at <t:{int((datetime.now() + duration).timestamp())} if need be.',
+            delete_after=15,
+        )
 
         return task
 

--- a/modron/tests/interact/test_reminder.py
+++ b/modron/tests/interact/test_reminder.py
@@ -55,6 +55,7 @@ async def test_msg_reminders(payload, followup, guild):
     # See that we follow up on the correct channel
     args = followup.parser.parse_args(['5 second'])
     task: Task = await followup.interact(args, payload)
+    assert 'I\'ll remind you at' in payload.last_message
     assert task is not None, payload.last_message
     await task
     assert task.result(), payload.last_message


### PR DESCRIPTION
Just so they know Modron received in and parsed correctly

Fixes #27 