### PR TITLE
Allow break times with more than one word

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,6 +2,8 @@ name: CI
 
 on: [push]
 
+concurrency: playbypost  # Places all jobs in the same concurrency group
+
 permissions:
   contents: read
 

--- a/modron/interact/reminder.py
+++ b/modron/interact/reminder.py
@@ -80,7 +80,7 @@ class ReminderModule(InteractionModule):
 
         # Subcommand for snoozing the reminder
         subparser = subparsers.add_parser('break', help='Delay the reminder thread for a certain time')
-        subparser.add_argument('time', help='How long to delay the reminder for', type=str)
+        subparser.add_argument('time', help='How long to delay the reminder for', type=str, nargs="+")
 
     async def interact(self, args: Namespace, context: Context):
         if args.reminder_command is None or args.reminder_command == 'status':
@@ -94,7 +94,8 @@ class ReminderModule(InteractionModule):
                 reply += f"\n\nLast message was from {state.last_message.sender} in #{state.last_message.channel}" \
                          f" <t:{int(state.last_message.last_time.timestamp())}:R>"
         elif args.reminder_command == 'break':
-            reply = _add_delay(context.guild.id, args.time)
+            delay_time = " ".join(args.time)
+            reply = _add_delay(context.guild.id, delay_time)
         else:
             raise ValueError('Support for {args.reminder_command} has not been implemented (blame Logan)')
 

--- a/modron/tests/interact/test_reminder.py
+++ b/modron/tests/interact/test_reminder.py
@@ -33,7 +33,7 @@ async def test_delay_status(payload, guild):
 
 @mark.asyncio
 async def test_delay_pause(payload):
-    args = reminders.parser.parse_args(['break', '1 second'])
+    args = reminders.parser.parse_args(['break', '1', 'second'])
     await reminders.interact(args, payload)
     assert 'paused' in payload.last_message.lower()
 


### PR DESCRIPTION
We used to use the ISO duration standard, which was always one word. We're now doing English specifications, which can be more.