### PR TITLE
Add option to route public rolls to same channel

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -30,7 +30,7 @@ describing what was wrong about your command.
 
 ![rolling_dice](img/roll-command.png)
 
-Modron supports all of the D&D 5e rules for dice rolling, such
+Modron supports all D&D 5e rules for dice rolling, such
 as advantage and re-rolling ones.
 Roll dice by calling `/modron roll`, `/mroll`, or just `/roll`.
 A few examples include:

--- a/modron/config.py
+++ b/modron/config.py
@@ -77,6 +77,7 @@ class TeamConfig(BaseModel):
     dice_tracked_categories: List[int] = Field(default_factory=list, help="List of categories of channel to track")
     blind_channel: str = Field("blind_rolls", help='Name of the channel on which to post blind rolls')
     blind_rolls: List[str] = Field(default=(), help='Purposes of rolls which are always blind')
+    public_channel: Optional[str] = Field(default=None, help='If provided, public roll results will be sent here')
 
     # Character sheets
     character_sheet_path: str = Field('characters', help='Path to a directory with the character sheet YAML files')

--- a/modron/interact/dice_roll.py
+++ b/modron/interact/dice_roll.py
@@ -3,6 +3,7 @@ import csv
 import json
 import logging
 import os
+import re
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
 from typing import List, NoReturn
@@ -17,6 +18,8 @@ from modron.interact.base import InteractionModule
 from modron.characters import list_available_characters, load_character
 
 logger = logging.getLogger(__name__)
+
+_private_channel_pattern = re.compile(r'(?:[-_]|^)gm(?:[-_]|$)')
 
 
 def _render_dice_rolls(roll: DiceRoll) -> List[str]:
@@ -210,31 +213,31 @@ class DiceRollInteraction(InteractionModule):
                         f' Result = {roll.value}')
         reply += f'\nRolls: {", ".join(_render_dice_rolls(roll))}'
 
-        # Determine whether to roll blindly or not
-        blind = True if ' '.join(args.purpose).lower() in config.team_options[context.guild.id].blind_rolls else False
-        if args.blind and not blind:
-            logger.info('Overriding default to make this roll blind')
-            blind = True
-        elif args.show and blind:
-            logger.info('Overriding default to show this roll')
-            blind = False
+        # Conditions which define where the dice roll is going
+        blind_channel = ' '.join(args.purpose).lower() in config.team_options[context.guild.id].blind_rolls
+        force_blind = args.blind
+        force_show = args.show
+        ic_channel = context.channel.name in config.team_options[context.guild.id].watch_channels
+        is_private = _private_channel_pattern.search(context.channel.name) is not None
+        has_public_channel = config.team_options[context.guild.id].public_channel is not None
 
-        if blind:
-            # Send the dice roll to the blind channel
+        # Send the result appropriate
+        if force_blind or (blind_channel and not force_show):  # Role blind
             channel_name = config.team_options[context.guild.id].blind_channel
             channel: TextChannel = utils.get(context.guild.channels, name=channel_name)
-            await channel.send(reply)
 
-            # Send a confirmation message as a reply
+            # Tell the user we are rolling blind
             await context.send(f'<@!{context.author.id}> rolled {roll.roll_description}, and '
                                'only the GM will see the result')
-        elif config.team_options[context.guild.id].public_channel is not None:
-            # Send to public channel if defined
+            await channel.send(reply)
+        elif (ic_channel and is_private) or not ic_channel or not has_public_channel:
+            # Reply in channel
+            await context.send(reply)
+        else:  # Public channel exists, we're in an IC channel and that channel is not private
+            # Reply in the public dice roll
             channel_name = config.team_options[context.guild.id].public_channel
             channel: TextChannel = utils.get(context.guild.channels, name=channel_name)
             await channel.send(reply)
-        else:
-            await context.send(reply)
 
         # Log the dice roll
         self.log_dice_roll(context, roll, purpose)

--- a/modron/interact/dice_roll.py
+++ b/modron/interact/dice_roll.py
@@ -228,6 +228,11 @@ class DiceRollInteraction(InteractionModule):
             # Send a confirmation message as a reply
             await context.send(f'<@!{context.author.id}> rolled {roll.roll_description}, and '
                                'only the GM will see the result')
+        elif config.team_options[context.guild.id].public_channel is not None:
+            # Send to public channel if defined
+            channel_name = config.team_options[context.guild.id].public_channel
+            channel: TextChannel = utils.get(context.guild.channels, name=channel_name)
+            await channel.send(reply)
         else:
             await context.send(reply)
 

--- a/modron/interact/dice_roll.py
+++ b/modron/interact/dice_roll.py
@@ -58,18 +58,16 @@ _description = """Roll dice with all the options of D&D 5e.
 
 Dice are expressed in the format: `<number of dice>d<number of sides>[+|-]<modifier>`
 
+Dice results will be sent to the public roll channel for public in-character channels,
+a GM-only channel if the roll is blind,
+and to the channel in which you made the roll otherwise.
+
 *examples*
 
-A common dice roll without any special rolls: `/modron roll 1d20+1`
-A common dice roll, with a defined purpose: `/modron roll 10d6+5 sneak attack damage`
+A common dice roll without any special rolls: `$modron roll 1d20+1`
+A common dice roll, with a defined purpose: `$modron roll 10d6+5 sneak attack damage`
 
-Option flags alter rules when rolling. Example: rolling at disadvantage: `/roll -d 1d20+2`
-
-If you have a character sheet registered, (call `/modron character` to find out) you can
-instead list the name of the ability you wish to roll. For example, `/roll str save` to
-roll a strength save.
-
-Call `/modron roll --help` for full details
+Option flags alter rules when rolling. Example: rolling at disadvantage: `$roll -d 1d20+2`
 """
 
 

--- a/modron/tests/interact/test_dice_command.py
+++ b/modron/tests/interact/test_dice_command.py
@@ -108,9 +108,11 @@ async def test_blind_roll(parser, roller, payload, guild: Guild):
 
     # See if it was reported in the "blind_channel"
     sleep(5)
-    reminder_channel = utils.get(guild.channels, name="bot_testing")
-    assert (timestamp_to_local_tz(reminder_channel.last_message.created_at) - datetime.now()).total_seconds() < 5
-    await reminder_channel.last_message.delete()
+    reminder_channel: TextChannel = utils.get(guild.channels, name="bot_testing")
+    async for last_message in reminder_channel.history(limit=1, oldest_first=False):
+        break
+    assert (timestamp_to_local_tz(last_message.created_at) - datetime.now()).total_seconds() < 5
+    await last_message.delete()
 
     # Make sure perception starts out at blind
     args = parser.parse_args(['perception'])
@@ -130,6 +132,7 @@ async def test_public_channel(parser, roller, payload, guild: Guild):
     """Test routing rolls to a public channel"""
     # Set the public channel
     config.team_options[guild.id].public_channel = 'bot_testing'
+    config.team_options[guild.id].watch_channels.append('bot_testing')
 
     # Test a regular roll
     args = parser.parse_args(['luck', '--show'])
@@ -146,3 +149,10 @@ async def test_public_channel(parser, roller, payload, guild: Guild):
     assert args.blind
     await roller.interact(args, payload)
     assert 'only the GM will see the result' in payload.last_message
+
+    # Make sure it replies back on a private channel
+    payload.channel.name = 'bot_testing_gm'
+    config.team_options[guild.id].watch_channels.append('bot_testing_gm')
+    args = parser.parse_args(['luck', '--show'])
+    await roller.interact(args, payload)
+    assert 'luck' in payload.last_message


### PR DESCRIPTION
Fixes #42 

A few requests from the GM:
- [x] Continue routing blind rolls to GM-only channel
- [x] Keep rolls from private channels (denoted with `[_-]GM[_-$]`) in channel