### PR TITLE
List out commands when calling `$modron`

### DIFF
--- a/modron/interact/__init__.py
+++ b/modron/interact/__init__.py
@@ -56,12 +56,12 @@ def attach_commands(bot: ModronClient, modules: Sequence[InteractionModule]) -> 
     return parser
 
 
-async def handle_generic_command(parser: NoExitParser, context: Context, *args):
-    """Respond to a generic "/modron" slash command
+async def handle_generic_command(parser: NoExitParser, modules: Sequence[InteractionModule], context: Context, *args):
+    """Respond to a generic "modron" command
 
     Args:
         parser: Parser to use to understand command
-        context: Slash command data sent from Slack
+        context: Command data sent from Discord
         args: Arguments passed to the command
     """
 
@@ -77,9 +77,11 @@ async def handle_generic_command(parser: NoExitParser, context: Context, *args):
 
     # If there is not an interact command, return help message
     if not hasattr(args, 'interact'):
-        parser.print_help()
-        msg = parser.text_buffer.getvalue()
-        logger.info(f'Sending some help messages back. {repr(msg[:64])}...{len(msg)} char')
+        msg = 'Modron is here to help with roleplaying on Slack.\nIt comes installed with many commands:\n'
+        for module in modules:
+            msg += f"\n- `${module.name}`: {module.description}"
+
+        logger.info('Sending a list of command strings back.')
         await context.reply(msg, delete_after=60)
     else:
         await args.interact(args, context)

--- a/modron/tests/interact/test_omni.py
+++ b/modron/tests/interact/test_omni.py
@@ -18,12 +18,16 @@ async def test_omni(bot: ModronClient, payload: MockContext, guild):
     modules = [DiceRollInteraction()]
     parser = attach_commands(bot, modules)
 
+    # Run an empty command in
+    await handle_generic_command(parser, modules, payload)
+    assert '- `$roll`: ' in payload.last_message
+
     # Run the help command
-    await handle_generic_command(parser, payload, '-h')
+    await handle_generic_command(parser, modules, payload, '-h')
     assert "- `roll`" in payload.last_message
 
     # Run the roll command
-    await handle_generic_command(parser, payload, 'roll', 'd20')
+    await handle_generic_command(parser, modules, payload, 'roll', 'd20')
     roll_channel: TextChannel = utils.get(guild.channels, name="bot_testing")
     sleep(5.)
     async for last_message in roll_channel.history(limit=1, oldest_first=False):
@@ -32,5 +36,5 @@ async def test_omni(bot: ModronClient, payload: MockContext, guild):
     await last_message.delete()
 
     # Make an error
-    await handle_generic_command(parser, payload, 'nope')
+    await handle_generic_command(parser, modules, payload, 'nope')
     assert "invalid" in payload.last_message


### PR DESCRIPTION
Make it clear that you don't need to run them via `$modron`