### PR TITLE
Add ability for users to add aliases

### DIFF
--- a/characters/kaluth/modron.yml
+++ b/characters/kaluth/modron.yml
@@ -18,3 +18,5 @@ speed: 30
 saving_throws: []
 proficiencies:
   - history
+roll_aliases:
+  cheat: 20

--- a/modron/characters.py
+++ b/modron/characters.py
@@ -176,7 +176,10 @@ class Character(BaseModel):
 
     @property
     def initiative(self) -> int:
-        return self.dexterity_mod
+        output = self.dexterity_mod
+        if self.classes.get('bard', 0) >= 2:
+            output += self.proficiency_bonus // 2
+        return output
 
     @property
     def total_hit_points(self) -> int:
@@ -336,6 +339,8 @@ class Character(BaseModel):
             return mod + self.proficiency_bonus * 2
         elif name_lower in self.proficiencies:
             return mod + self.proficiency_bonus
+        elif self.classes.get('bard', 0) >= 2:
+            return mod + self.proficiency_bonus // 2
         else:
             return mod
 
@@ -351,6 +356,10 @@ class Character(BaseModel):
         # Make it all lowercase
         check = check.lower()
         words = check.split(" ")
+
+        # Start with initiative
+        if words == ['initiative'] or words == ['init']:
+            return self.initiative
 
         # Save
         if 'save' in words:

--- a/modron/interact/dice_roll.py
+++ b/modron/interact/dice_roll.py
@@ -194,9 +194,12 @@ class DiceRollInteraction(InteractionModule):
             sheet, _ = load_character(context.guild.id, character)
             ability_name = ' '.join([args.dice] + args.purpose)
 
-            # Lookup the ability
-            modifier = sheet.lookup_modifier(ability_name)
-            args.dice = f'1d20{modifier:+d}'
+            # Get the roll
+            if ability_name in sheet.roll_aliases:
+                args.dice = sheet.substitute_modifiers(sheet.roll_aliases[ability_name])
+            else:
+                modifier = sheet.lookup_modifier(ability_name)
+                args.dice = f'1d20{modifier:+d}'
             args.purpose = [ability_name]
             logger.info(f'Reformatted command to be for {ability_name} for {sheet.name}')
 

--- a/modron/tests/interact/conftest.py
+++ b/modron/tests/interact/conftest.py
@@ -1,10 +1,17 @@
 from discord import TextChannel, Guild, Message, Member
 from discord import utils
 from pytest_asyncio import fixture as async_fixture
+from pytest import fixture
 
 from modron.interact.dice_roll import DiceRollInteraction
+from modron import config
 
 _test_modules = [DiceRollInteraction]
+
+
+@fixture()
+def test_sheet_path(guild: Guild):
+    return config.config.get_character_sheet_path(guild.id, 'modron')
 
 
 class MockContext:

--- a/modron/tests/interact/test_character.py
+++ b/modron/tests/interact/test_character.py
@@ -1,14 +1,7 @@
-from discord import Guild
 from pytest import raises, fixture, mark
 
 from modron.characters import Character
-from modron.config import config
 from modron.interact.character import CharacterSheet, HPTracker
-
-
-@fixture()
-def test_sheet_path(guild: Guild):
-    return config.get_character_sheet_path(guild.id, 'modron')
 
 
 @fixture(autouse=True)

--- a/modron/tests/interact/test_character.py
+++ b/modron/tests/interact/test_character.py
@@ -142,3 +142,26 @@ async def test_harm_and_heal(payload, test_sheet_path):
         args = hp.parser.parse_args([sub, 'asdf'])
         with raises(ValueError):
             await hp.interact(args, payload)
+
+
+@mark.asyncio
+async def test_aliases(payload, test_sheet_path):
+    character = CharacterSheet()
+    parser = character.parser
+
+    args = parser.parse_args(['roll', 'list'])
+    await character.interact(args, payload)
+    assert payload.last_message.startswith('Available rolls')
+
+    args = parser.parse_args(['roll', 'set', 'damage', '1d6+str'])
+    await character.interact(args, payload)
+    assert payload.last_message.startswith('Set damage to mean "1d6+str')
+    assert 'damage' in Character.from_yaml(test_sheet_path).roll_aliases
+
+    args = parser.parse_args(['roll', 'remove', 'damage'])
+    await character.interact(args, payload)
+    assert payload.last_message.startswith('Removed damage')
+
+    args = parser.parse_args(['roll', 'list'])
+    await character.interact(args, payload)
+    assert 'damage' not in payload.last_message

--- a/modron/tests/interact/test_dice_command.py
+++ b/modron/tests/interact/test_dice_command.py
@@ -93,6 +93,11 @@ async def test_ability_roll(parser, roller, payload):
     await roller.interact(args, payload)
     assert 'at advantage' in payload.last_message
 
+    # Test an alias
+    args = parser.parse_args(['cheat'])
+    await roller.interact(args, payload)
+    assert '20' in payload.last_message
+
 
 @mark.asyncio()
 async def test_blind_roll(parser, roller, payload, guild: Guild):

--- a/modron/tests/test_characters.py
+++ b/modron/tests/test_characters.py
@@ -4,7 +4,6 @@ from pytest import fixture, raises
 
 from modron.characters import Character
 
-
 _joe_path = os.path.join(os.path.dirname(__file__), 'joe.yaml')
 
 
@@ -141,3 +140,19 @@ def test_temporary_hit_points(joe):
     # Reset
     joe.reset_hit_point_maximum()
     assert joe.current_hit_point_maximum == joe.hit_points
+
+
+def test_jack_of_all_trades(joe):
+    # Make Joe a bard
+    joe.classes['bard'] = 2
+
+    # Test initiative
+    assert joe.initiative == joe.dexterity_mod + joe.proficiency_bonus // 2
+    assert joe.lookup_modifier('initiative') == joe.dexterity_mod + joe.proficiency_bonus // 2
+
+    # No additional bonus to proficient skills
+    assert joe.skill_modifier('medicine') == joe.wisdom_mod + joe.proficiency_bonus
+    assert joe.skill_modifier('athletics') == joe.strength_mod + joe.proficiency_bonus * 2
+
+    # But a bonus to others
+    assert joe.skill_modifier('insight') == joe.wisdom_mod + joe.proficiency_bonus // 2

--- a/modron/tests/test_characters.py
+++ b/modron/tests/test_characters.py
@@ -156,3 +156,18 @@ def test_jack_of_all_trades(joe):
 
     # But a bonus to others
     assert joe.skill_modifier('insight') == joe.wisdom_mod + joe.proficiency_bonus // 2
+
+
+def test_complex_roll(joe):
+    """Test a roll which combines dice types and sheet modifiers"""
+
+    simplified = joe.substitute_modifiers('1d20+2')
+    assert simplified == '1d20+2'
+
+    # Try an attribute
+    simplified = joe.substitute_modifiers('1d20+STR')
+    assert simplified == f'1d20+{joe.strength_mod}'
+
+    # Try a skill
+    simplified = joe.substitute_modifiers('1d21+3d6 + animal handling-3')
+    assert simplified == f"1d21+3d6{joe.skill_modifier('animal handling') - 3:+d}"


### PR DESCRIPTION
Let users set aliases for rolls they commonly make. The rolls will be stored on the character sheet and available through the `$roll` command

Fixes #11 